### PR TITLE
Switch actions/checkout to major v3 version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: go get


### PR DESCRIPTION
It's a bit of a pain to constantly update patch versions, as this is just CI and unrelated to the main focus which is the codebase. So in these cases, I don't want to run CI again just because the `checkout` action had an update.